### PR TITLE
Move example workflows from the README to usable actions

### DIFF
--- a/actions/assume_role.py
+++ b/actions/assume_role.py
@@ -1,5 +1,7 @@
 import json
+import os
 import boto3
+from botocore.exceptions import ClientError
 
 from st2common.runners.base_action import Action
 
@@ -8,26 +10,49 @@ from lib.util import json_serial
 
 # pylint: disable=too-few-public-methods
 class Boto3AssumeRoleRunner(Action):
-    def run(
-            self, role_arn, role_session_name, policy,
-            duration, external_id, serial_number, token_code):
-        client = boto3.client('sts')
-        kwargs = {}
-        kwargs['RoleArn'] = role_arn
-        kwargs['RoleSessionName'] = role_session_name
-        kwargs['DurationSeconds'] = duration
+    def run(self, role_arn,
+            policy=None, duration=3600, external_id=None,
+            aws_access_key_id=None, aws_secret_access_key=None,
+            use_mfa=False, serial_number=None, token_code=None):
+
+        success = False
+        result = dict()
+
+        sts_kwargs=dict()
+
+        if aws_access_key_id and aws_secret_access_key:
+            sts_kwargs['aws_access_key_id'] = aws_access_key_id
+            sts_kwargs['aws_secret_access_key'] = aws_secret_access_key
+
+        client = boto3.client('sts', **sts_kwargs)
+
+        # Dynamically build the RoleSessionName with the action execution so we know it's unique.
+        role_session_name = "ST2AssumeRole_{}".format(os.environ['ST2_ACTION_EXECUTION_ID'])
+
+        kwargs = {
+            'RoleArn': role_arn,
+            'RoleSessionName': role_session_name,
+            'DurationSeconds': duration,
+        }
+
         if policy is not None:
             kwargs['Policy'] = policy
 
         if external_id is not None:
             kwargs['ExternalId'] = external_id
 
-        if serial_number is not None:
+        if use_mfa:
             kwargs['SerialNumber'] = serial_number
-
-        if token_code is not None:
             kwargs['TokenCode'] = token_code
 
-        response = client.assume_role(**kwargs)
-        response = json.loads(json.dumps(response, default=json_serial))
-        return (True, response)
+        try:
+            response = client.assume_role(**kwargs)
+        except ClientError as e:
+            result['error'] = e.message
+        else
+            response = json.loads(json.dumps(response, default=json_serial))
+            result['AssumedRoleUser'] = response['AssumedRoleUser']
+            result['Credentials'] = response['Credentials']
+            success = True
+
+        return success, result

--- a/actions/assume_role.py
+++ b/actions/assume_role.py
@@ -49,7 +49,7 @@ class Boto3AssumeRoleRunner(Action):
             response = client.assume_role(**kwargs)
         except ClientError as e:
             result['error'] = e.message
-        else
+        else:
             response = json.loads(json.dumps(response, default=json_serial))
             result['AssumedRoleUser'] = response['AssumedRoleUser']
             result['Credentials'] = response['Credentials']

--- a/actions/assume_role.py
+++ b/actions/assume_role.py
@@ -18,7 +18,7 @@ class Boto3AssumeRoleRunner(Action):
         success = False
         result = dict()
 
-        sts_kwargs=dict()
+        sts_kwargs = dict()
 
         if aws_access_key_id and aws_secret_access_key:
             sts_kwargs['aws_access_key_id'] = aws_access_key_id

--- a/actions/assume_role.yaml
+++ b/actions/assume_role.yaml
@@ -10,20 +10,28 @@ parameters:
     type: "string"
     description: "ARN of the role"
     required: true
-  role_session_name:
-    type: "string"
-    description: "Name for the session"
-    default: "DefaultAssumeSession"
   policy:
     type: "string"
     description: "Policy document"
+  aws_access_key_id:
+    type: "string"
+    description: "AWS Access Key"
+    secret: true
+  aws_secret_access_key:
+    type: "string"
+    description: "AWS Secret Access Key"
+    secret: true
   duration:
     type: integer
-    description: "Duration for the session"
+    description: "Duration (seconds) for the session"
     default: 3600
   external_id:
     type: "string"
     description: "External Id"
+  use_mfa:
+    type: "boolean"
+    description: "Include MFA details."
+    default: False
   serial_number:
     type: "string"
     description: "Serial number of the MFA"

--- a/actions/boto3action.py
+++ b/actions/boto3action.py
@@ -21,7 +21,7 @@ class Boto3ActionRunner(Action):
             client = boto3.client(service, region_name=region)
 
         if client is None:
-            return (False, 'boto3 client creation failed')
+            return False, 'boto3 client creation failed'
 
         if params is not None:
             response = getattr(client, action_name)(**params)
@@ -29,4 +29,4 @@ class Boto3ActionRunner(Action):
             response = getattr(client, action_name)()
 
         response = json.loads(json.dumps(response, default=json_serial))
-        return (True, response)
+        return True, response

--- a/actions/create_vpc.yaml
+++ b/actions/create_vpc.yaml
@@ -1,0 +1,25 @@
+---
+name: "create_vpc"
+pack: aws_boto3
+runner_type: "mistral-v2"
+description: "Create VPC with boto3action"
+enabled: true
+entry_point: "workflows/create_vpc.yaml"
+parameters:
+  cidr_block:
+    type: "string"
+    description: "VPC CIDR block"
+    required: true
+  region:
+    type: "string"
+    description: "Region to create VPC"
+    required: true
+  subnet_cidr_block:
+    type: "string"
+    description: "Subnet CIDR block"
+    required: true
+  availability_zone:
+    type: "string"
+    description: "Availability zone to create subnet"
+    required: true
+...

--- a/actions/create_vpc_assume_role.yaml
+++ b/actions/create_vpc_assume_role.yaml
@@ -1,0 +1,29 @@
+---
+name: "create_vpc_assume_role"
+pack: aws_boto3
+runner_type: "mistral-v2"
+description: "Create VPC with boto3action using assume_role"
+enabled: true
+entry_point: "workflows/create_vpc_assume_role.yaml"
+parameters:
+  role_arn:
+    type: "string"
+    description: "ARN of the role to assume"
+    required: true
+  cidr_block:
+    type: "string"
+    description: "VPC CIDR block"
+    required: true
+  region:
+    type: "string"
+    description: "Region to create VPC"
+    required: true
+  subnet_cidr_block:
+    type: "string"
+    description: "Subnet CIDR block"
+    required: true
+  availability_zone:
+    type: "string"
+    description: "Availability zone to create subnet"
+    required: true
+...

--- a/actions/create_vpc_assume_role.yaml
+++ b/actions/create_vpc_assume_role.yaml
@@ -6,10 +6,6 @@ description: "Create VPC with boto3action using assume_role"
 enabled: true
 entry_point: "workflows/create_vpc_assume_role.yaml"
 parameters:
-  role_arn:
-    type: "string"
-    description: "ARN of the role to assume"
-    required: true
   cidr_block:
     type: "string"
     description: "VPC CIDR block"
@@ -26,4 +22,26 @@ parameters:
     type: "string"
     description: "Availability zone to create subnet"
     required: true
+  role_arn:
+    type: "string"
+    description: "ARN of the role"
+    required: true
+  aws_access_key_id:
+    type: "string"
+    description: "AWS Access Key"
+    secret: true
+  aws_secret_access_key:
+    type: "string"
+    description: "AWS Secret Access Key"
+    secret: true
+  use_mfa:
+    type: "boolean"
+    description: "Include MFA details."
+    default: False
+  serial_number:
+    type: "string"
+    description: "Serial number of the MFA"
+  token_code:
+    type: "string"
+    description: "Token code from the MFA"
 ...

--- a/actions/workflows/create_vpc.yaml
+++ b/actions/workflows/create_vpc.yaml
@@ -1,0 +1,88 @@
+---
+version: '2.0'
+aws_boto3.create_vpc:
+    type: direct
+    description: "Create VPC with boto3action"
+    input:
+        - cidr_block
+        - region
+        - subnet_cidr_block
+        - availability_zone
+    tasks:
+      create_vpc:
+        action: aws_boto3.boto3action
+        input:
+          service: ec2
+          action_name: create_vpc
+          region: <% $.region %>
+          params: <% dict(CidrBlock => $.cidr_block, InstanceTenancy => "default") %>
+        publish:
+          vpc_id: <% task(create_vpc).result.result.Vpc.VpcId %>
+        on-success:
+          - create_subnet
+          - create_igw
+
+      create_subnet:
+        action: aws_boto3.boto3action
+        input:
+          service: ec2
+          action_name: create_subnet
+          region: <% $.region %>
+          params: <% dict(AvailabilityZone => $.availability_zone, CidrBlock => $.subnet_cidr_block, VpcId => $.vpc_id) %>
+        publish:
+          subnet_id: <% task(create_subnet).result.result.Subnet.SubnetId %>
+        on-success:
+          - create_route_table
+
+      create_igw:
+        action: aws_boto3.boto3action
+        input:
+          service: ec2
+          action_name: create_internet_gateway
+          region: <% $.region %>
+        publish:
+          igw_id: <% task(create_igw).result.result.InternetGateway.InternetGatewayId %>
+        on-success:
+          - attach_igw
+
+      attach_igw:
+        action: aws_boto3.boto3action
+        input:
+          service: ec2
+          action_name: attach_internet_gateway
+          region: <% $.region %>
+          params: <% dict(VpcId => $.vpc_id, InternetGatewayId => $.igw_id) %>
+        on-success:
+          - create_route_igw
+
+      create_route_table:
+        action: aws_boto3.boto3action
+        input:
+          service: ec2
+          action_name: create_route_table
+          region: <% $.region %>
+          params: <% dict(VpcId => $.vpc_id) %>
+        publish:
+          route_table_id: <% task(create_route_table).result.result.RouteTable.RouteTableId %>
+        on-success:
+          - attach_route_tables
+
+      attach_route_tables:
+        action: aws_boto3.boto3action
+        input:
+          service: ec2
+          action_name: associate_route_table
+          region: <% $.region %>
+          params: <% dict(SubnetId => $.subnet_id, RouteTableId => $.route_table_id) %>
+        on-success:
+          - create_route_igw
+
+      create_route_igw:
+        join: 2
+        action: aws_boto3.boto3action
+        input:
+          service: ec2
+          action_name: create_route
+          region: <% $.region %>
+          params: <% dict(RouteTableId => $.route_table_id, GatewayId => $.igw_id, DestinationCidrBlock => '0.0.0.0/0') %>
+...

--- a/actions/workflows/create_vpc.yaml
+++ b/actions/workflows/create_vpc.yaml
@@ -78,7 +78,7 @@ aws_boto3.create_vpc:
           - create_route_igw
 
       create_route_igw:
-        join: 2
+        join: all
         action: aws_boto3.boto3action
         input:
           service: ec2

--- a/actions/workflows/create_vpc_assume_role.yaml
+++ b/actions/workflows/create_vpc_assume_role.yaml
@@ -1,0 +1,105 @@
+---
+version: '2.0'
+aws_boto3.create_vpc_assume_role:
+    type: direct
+    description: "Create VPC with boto3action"
+    input:
+        - cidr_block
+        - region
+        - subnet_cidr_block
+        - availability_zone
+        - role_arn
+    tasks:
+      assume_role:
+        action: aws_boto3.assume_role
+        input:
+          role_arn: <% $.role_arn %>
+        publish:
+          credentials: <% task(assume_role).result.result %>
+        on-success:
+          - create_vpc
+
+      create_vpc:
+        action: aws_boto3.boto3action
+        input:
+          service: ec2
+          action_name: create_vpc
+          region: <% $.region %>
+          params: <% dict(CidrBlock => $.cidr_block, InstanceTenancy => "default") %>
+          credentials: <% $.credentials %>
+        publish:
+          vpc_id: <% task(create_vpc).result.result.Vpc.VpcId %>
+        on-success:
+          - create_subnet
+          - create_igw
+
+      create_subnet:
+        action: aws_boto3.boto3action
+        input:
+          service: ec2
+          action_name: create_subnet
+          region: <% $.region %>
+          params: <% dict(AvailabilityZone => $.availability_zone, CidrBlock => $.subnet_cidr_block, VpcId => $.vpc_id) %>
+          credentials: <% $.credentials %>
+        publish:
+          subnet_id: <% task(create_subnet).result.result.Subnet.SubnetId %>
+        on-success:
+          - create_route_table
+
+      create_igw:
+        action: aws_boto3.boto3action
+        input:
+          service: ec2
+          action_name: create_internet_gateway
+          region: <% $.region %>
+          credentials: <% $.credentials %>
+        publish:
+          igw_id: <% task(create_igw).result.result.InternetGateway.InternetGatewayId %>
+        on-success:
+          - attach_igw
+
+      attach_igw:
+        action: aws_boto3.boto3action
+        input:
+          service: ec2
+          action_name: attach_internet_gateway
+          region: <% $.region %>
+          params: <% dict(VpcId => $.vpc_id, InternetGatewayId => $.igw_id) %>
+          credentials: <% $.credentials %>
+        on-success:
+          - create_route_igw
+
+      create_route_table:
+        action: aws_boto3.boto3action
+        input:
+          service: ec2
+          action_name: create_route_table
+          region: <% $.region %>
+          params: <% dict(VpcId => $.vpc_id) %>
+          credentials: <% $.credentials %>
+        publish:
+          route_table_id: <% task(create_route_table).result.result.RouteTable.RouteTableId %>
+        on-success:
+          - attach_route_tables
+
+      attach_route_tables:
+        action: aws_boto3.boto3action
+        input:
+          service: ec2
+          action_name: associate_route_table
+          region: <% $.region %>
+          params: <% dict(SubnetId => $.subnet_id, RouteTableId => $.route_table_id) %>
+          credentials: <% $.credentials %>
+        on-success:
+          - create_route_igw
+
+      create_route_igw:
+        join: 2
+        action: aws_boto3.boto3action
+        input:
+          service: ec2
+          action_name: create_route
+          region: <% $.region %>
+          params: <% dict(RouteTableId => $.route_table_id, GatewayId => $.igw_id, DestinationCidrBlock => '0.0.0.0/0') %>
+          credentials: <% $.credentials %>
+...

--- a/actions/workflows/create_vpc_assume_role.yaml
+++ b/actions/workflows/create_vpc_assume_role.yaml
@@ -9,11 +9,22 @@ aws_boto3.create_vpc_assume_role:
         - subnet_cidr_block
         - availability_zone
         - role_arn
+        - aws_access_key_id
+        - aws_secret_access_key
+        - use_mfa
+        - serial_number
+        - token_code
     tasks:
       assume_role:
         action: aws_boto3.assume_role
         input:
           role_arn: <% $.role_arn %>
+          aws_access_key_id: <% $.aws_access_key_id %>
+          aws_secret_access_key: <% $.aws_secret_access_key %>
+          use_mfa: <% $.use_mfa %>
+          serial_number: <% $.serial_number %>
+          token_code: <% $.token_code %>
+
         publish:
           credentials: <% task(assume_role).result.result %>
         on-success:

--- a/pack.yaml
+++ b/pack.yaml
@@ -20,7 +20,7 @@ keywords:
   - SQS
   - lambda
 
-version : 0.2.0
+version : 0.3.0
 author : StackStorm, Inc.
 email : info@stackstorm.com
 contributors:


### PR DESCRIPTION
Adds the following actions and workflows for based on the examples in the REAME:

- `create_vpc`.
- `create_vpc_assume_role`.

And updates the README with any required changes.