### PR TITLE
Ensure credentials are correctly hidden when running on 2.8.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,12 @@
 ## Change Log
 
+## v0.5.0
+- Disable both the example workflows.
+- Mark `token_code` on `assume_role` as a secret.
+- Fix example `create_vpn_assume_role` workflow to correctly publish `credentials` 
+  and `assumed_role_user` details.
+- Add `properties` to `credentials` on `boto3action`.
+
 ## v0.4.0
 - Add missing CHANGES file.
 - Update requirement on `boto3` so it's not so restrictive.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,7 +5,7 @@
 - Mark `token_code` on `assume_role` as a secret.
 - Fix example `create_vpn_assume_role` workflow to correctly publish `credentials` 
   and `assumed_role_user` details.
-- Add `properties` to `credentials` on `boto3action`.
+- Add `properties` to `credentials` on `boto3action` and `waiter`.
 
 ## v0.4.0
 - Add missing CHANGES file.

--- a/actions/assume_role.yaml
+++ b/actions/assume_role.yaml
@@ -38,3 +38,4 @@ parameters:
   token_code:
     type: "string"
     description: "Token code from the MFA"
+    secret: true

--- a/actions/boto3action.py
+++ b/actions/boto3action.py
@@ -8,17 +8,20 @@ from lib.util import json_serial
 # pylint: disable=too-few-public-methods
 class Boto3ActionRunner(Action):
     def run(self, service, region, action_name, credentials, params):
-        client = None
-        response = None
 
         if credentials is not None:
-            session = boto3.Session(
-                aws_access_key_id=credentials['Credentials']['AccessKeyId'],
-                aws_secret_access_key=credentials['Credentials']['SecretAccessKey'],
-                aws_session_token=credentials['Credentials']['SessionToken'])
-            client = session.client(service, region_name=region)
-        else:
-            client = boto3.client(service, region_name=region)
+
+            # This is backwards compatibility for a bug from the boto3 branch
+            # of the aws pack.
+            if 'Credentials' in credentials:
+                credentials = credentials['Credentials']
+
+            session_kwargs['aws_access_key_id'] = credentials['AccessKeyId']
+            session_kwargs['aws_secret_access_key'] = credentials['SecretAccessKey']
+            session_kwargs['aws_session_token'] = credentials['SessionToken']
+
+        session = boto3.Session(**session_kwargs)
+        client = session.client(service, region_name=region)
 
         if client is None:
             return False, 'boto3 client creation failed'

--- a/actions/boto3action.py
+++ b/actions/boto3action.py
@@ -11,7 +11,6 @@ class Boto3ActionRunner(Action):
         session_kwargs = {}
 
         if credentials is not None:
-
             # This is backwards compatibility for a bug from the boto3 branch
             # of the aws pack.
             if 'Credentials' in credentials:

--- a/actions/boto3action.py
+++ b/actions/boto3action.py
@@ -8,6 +8,7 @@ from lib.util import json_serial
 # pylint: disable=too-few-public-methods
 class Boto3ActionRunner(Action):
     def run(self, service, region, action_name, credentials, params):
+        session_kwargs = {}
 
         if credentials is not None:
 

--- a/actions/boto3action.yaml
+++ b/actions/boto3action.yaml
@@ -21,8 +21,21 @@ parameters:
   credentials:
     type: "object"
     description: "Response from assume role"
-    secret: true
+    properties:
+      AccessKeyId:
+        type: string
+        secret: true
+      Expiration:
+        type: string
+      SecretAccessKey:
+        type: string
+        secret: true
+      SessionToken:
+        type: string
+        secret: true
+      Credentials:
+        type: "object"
+        secret: true
   params:
     type: object
     description: "Parameters for the action"
-

--- a/actions/create_vpc.yaml
+++ b/actions/create_vpc.yaml
@@ -3,7 +3,7 @@ name: "create_vpc"
 pack: aws_boto3
 runner_type: "mistral-v2"
 description: "Create VPC with boto3action"
-enabled: true
+enabled: false
 entry_point: "workflows/create_vpc.yaml"
 parameters:
   cidr_block:

--- a/actions/create_vpc_assume_role.yaml
+++ b/actions/create_vpc_assume_role.yaml
@@ -3,7 +3,7 @@ name: "create_vpc_assume_role"
 pack: aws_boto3
 runner_type: "mistral-v2"
 description: "Create VPC with boto3action using assume_role"
-enabled: true
+enabled: false
 entry_point: "workflows/create_vpc_assume_role.yaml"
 parameters:
   cidr_block:

--- a/actions/waiter.py
+++ b/actions/waiter.py
@@ -12,7 +12,6 @@ class WaiterRunner(Action):
         service_waiter = None
         session_kwargs = {}
 
-
         if 'WaiterConfig' not in params:
             # We should wait no more than 300 seconds
             params['WaiterConfig'] = {'MaxAttempts': max_attempts}

--- a/actions/waiter.py
+++ b/actions/waiter.py
@@ -8,22 +8,27 @@ from st2common.runners.base_action import Action
 class WaiterRunner(Action):
     def run(self, service, region, waiter_name, credentials, params, max_attempts=20):
         success = False
-        client = None
         result = dict()
         service_waiter = None
+        session_kwargs = {}
+
 
         if 'WaiterConfig' not in params:
             # We should wait no more than 300 seconds
             params['WaiterConfig'] = {'MaxAttempts': max_attempts}
 
         if credentials is not None:
-            session = boto3.Session(
-                aws_access_key_id=credentials['Credentials']['AccessKeyId'],
-                aws_secret_access_key=credentials['Credentials']['SecretAccessKey'],
-                aws_session_token=credentials['Credentials']['SessionToken'])
-            client = session.client(service, region_name=region)
-        else:
-            client = boto3.client(service, region_name=region)
+            # This is backwards compatibility for a bug from the boto3 branch
+            # of the aws pack.
+            if 'Credentials' in credentials:
+                credentials = credentials['Credentials']
+
+            session_kwargs['aws_access_key_id'] = credentials['AccessKeyId']
+            session_kwargs['aws_secret_access_key'] = credentials['SecretAccessKey']
+            session_kwargs['aws_session_token'] = credentials['SessionToken']
+
+        session = boto3.Session(**session_kwargs)
+        client = session.client(service, region_name=region)
 
         if client is None:
             return False, 'boto3 client creation failed'

--- a/actions/waiter.yaml
+++ b/actions/waiter.yaml
@@ -21,7 +21,21 @@ parameters:
   credentials:
     type: "object"
     description: "Response from assume role"
-    secret: true
+    properties:
+      AccessKeyId:
+        type: string
+        secret: true
+      Expiration:
+        type: string
+      SecretAccessKey:
+        type: string
+        secret: true
+      SessionToken:
+        type: string
+        secret: true
+      Credentials:
+        type: "object"
+        secret: true
   params:
     type: object
     description: "Parameters for the action"

--- a/actions/workflows/create_vpc_assume_role.yaml
+++ b/actions/workflows/create_vpc_assume_role.yaml
@@ -26,7 +26,9 @@ aws_boto3.create_vpc_assume_role:
           token_code: <% $.token_code %>
 
         publish:
-          credentials: <% task(assume_role).result.result %>
+          credentials: <% task().result.result['Credentials'] %>
+          assumed_role_user: <% task().result.result['AssumedRoleUser'] %>
+
         on-success:
           - create_vpc
 
@@ -39,7 +41,7 @@ aws_boto3.create_vpc_assume_role:
           params: <% dict(CidrBlock => $.cidr_block, InstanceTenancy => "default") %>
           credentials: <% $.credentials %>
         publish:
-          vpc_id: <% task(create_vpc).result.result.Vpc.VpcId %>
+          vpc_id: <% task().result.result.Vpc.VpcId %>
         on-success:
           - create_subnet
           - create_igw
@@ -53,7 +55,7 @@ aws_boto3.create_vpc_assume_role:
           params: <% dict(AvailabilityZone => $.availability_zone, CidrBlock => $.subnet_cidr_block, VpcId => $.vpc_id) %>
           credentials: <% $.credentials %>
         publish:
-          subnet_id: <% task(create_subnet).result.result.Subnet.SubnetId %>
+          subnet_id: <% task().result.result.Subnet.SubnetId %>
         on-success:
           - create_route_table
 
@@ -65,7 +67,7 @@ aws_boto3.create_vpc_assume_role:
           region: <% $.region %>
           credentials: <% $.credentials %>
         publish:
-          igw_id: <% task(create_igw).result.result.InternetGateway.InternetGatewayId %>
+          igw_id: <% task().result.result.InternetGateway.InternetGatewayId %>
         on-success:
           - attach_igw
 
@@ -89,7 +91,7 @@ aws_boto3.create_vpc_assume_role:
           params: <% dict(VpcId => $.vpc_id) %>
           credentials: <% $.credentials %>
         publish:
-          route_table_id: <% task(create_route_table).result.result.RouteTable.RouteTableId %>
+          route_table_id: <% task().result.result.RouteTable.RouteTableId %>
         on-success:
           - attach_route_tables
 

--- a/pack.yaml
+++ b/pack.yaml
@@ -20,7 +20,7 @@ keywords:
   - SQS
   - lambda
 
-version : 0.4.0
+version : 0.5.0
 author : StackStorm, Inc.
 email : info@stackstorm.com
 contributors:


### PR DESCRIPTION
Some fixes that have come to light during testing.

- Disable both the example workflows.
- Mark `token_code` on `assume_role` as a secret.
- Fix example `create_vpn_assume_role` workflow to correctly publish `credentials` and `assumed_role_user` details.
- Add `properties` to `credentials` on `boto3action` and `waiter`.
