### PR TITLE
Add `create_instance` workflow

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 ## Change Log
 
+## v0.7.0
+- Add `create_instance` workflow.
+
 ## v0.6.0
 - Disable both the example workflows.
 - Mark `token_code` on `assume_role` as a secret.

--- a/README.md
+++ b/README.md
@@ -60,6 +60,30 @@ st2 run aws_boto3.boto3action service="ec2" action_name="describe_vpcs" region="
 See the Boto3 documentation for more [information on profiles](http://boto3.readthedocs.io/en/latest/guide/configuration.html#shared-credentials-file).
 
 
+## Example workflow - Create instance
+
+### aws_boto3.create_instance
+
+Create an EC2 instance with defined keypair, subnet and security group:
+
+```
+st2 run aws_boto3.create_instance \
+  region=us-east-1 \
+  ImageId=ami-1234abcd \
+  KeyName=deployment-key \
+  SubnetId=subnet-5678efef \
+  SecurityGroupIds='["sg-dcba9100"]'
+```
+
+Create an instance and assign tags:
+
+```
+st2 run --auto-dict aws_boto3.create_instance \
+  ImageId=ami-1234abcd \
+  Tags=Name:my-instance \
+  Tags=Owner:me@example.com
+```
+
 ## Example workflow - Create VPC
 
 ### aws_boto3.create_vpc

--- a/actions/create_instance.yaml
+++ b/actions/create_instance.yaml
@@ -1,0 +1,38 @@
+---
+name: "create_instance"
+pack: "aws_boto3"
+runner_type: "action-chain"
+description: "Create EC2 instance and assign tags"
+enabled: true
+entry_point: "workflows/create_instance.yaml"
+parameters:
+  region:
+    type: "string"
+    description: "Region to create EC2 instance in"
+    default: "us-east-1"
+  ImageId:
+    type: "string"
+    description: "AWS image ID to create instance from"
+    required: true
+  InstanceType:
+    type: "string"
+    description: "Flavor to use for instance creation"
+    default: "t2.nano"
+  SecurityGroupIds:
+    type: "array"
+    description: "AWS Security Group IDs"
+    default: []
+  SubnetId:
+    type: "string"
+    description: "AWS Subnet ID"
+    required: false
+  KeyName:
+    type: "string"
+    description: "SSH key to use during intial instance creation"
+    required: false
+  Tags:
+    type: "array"
+    items:
+      type: "object"
+    description: "A list of AWS tag objects in form of [{'Key1': 'Value1'}, {'Key2': 'Value2'}, ...]"
+    default: ["Creator": "StackStorm aws_boto3.create_instance workflow"]

--- a/actions/workflows/create_instance.yaml
+++ b/actions/workflows/create_instance.yaml
@@ -1,0 +1,60 @@
+---
+# Render param objects as miltiline YAML string for later serialization
+# with skipping unnecessary keys.
+vars:
+  params: |-
+      MinCount: 1
+      MaxCount: 1
+      ImageId: "{{ImageId}}"
+      InstanceType: "{{InstanceType}}"
+      # Handle SecurityGroupIds as valid array
+      SecurityGroupIds: {{SecurityGroupIds|to_json_string}}
+      {% if SubnetId %}
+      SubnetId: "{{SubnetId}}"
+      {% endif %}
+      {% if KeyName %}
+      KeyName: "{{KeyName}}"
+      {% endif %}
+
+  # Transoform ``Tags`` array for Boto3 call
+  tags: |-
+      {% for i in Tags %}
+      - Key: "{{ i.keys()|first }}"
+        Value: "{{ i.values()|first }}"
+      {% endfor %}
+
+chain:
+  -
+    name: "run_instance"
+    ref: "aws_boto3.boto3action"
+    params:
+      service: "ec2"
+      action_name: "run_instances"
+      region: "{{region}}"
+      params: "{{params|from_yaml_string}}"
+    on-success: "wait_for_instance"
+  -
+    name: "wait_for_instance"
+    ref: "aws_boto3.waiter"
+    params:
+      service: "ec2"
+      waiter_name: "instance_running"
+      region: "{{region}}"
+      params:
+        InstanceIds:
+          - "{{run_instance.result.Instances[0].InstanceId}}"
+    on-success: "add_tags"
+  -
+    name: "add_tags"
+    ref: "aws_boto3.boto3action"
+    params:
+      service: "ec2"
+      action_name: "create_tags"
+      region: "{{region}}"
+      params: >-
+          {{
+            {
+              'Resources': [run_instance.result.Instances[0].InstanceId],
+              'Tags': tags|from_yaml_string
+            }
+          }}

--- a/pack.yaml
+++ b/pack.yaml
@@ -20,8 +20,9 @@ keywords:
   - SQS
   - lambda
 
-version : 0.6.0
+version : 0.7.0
 author : StackStorm, Inc.
 email : info@stackstorm.com
 contributors:
   - Jon Middleton <jjm@geeky-and-blonde.me.uk>
+  - Denys Havrysh <denys.gavrysh@gmail.com>


### PR DESCRIPTION
This PR adds an example action-chain based workflow named `create_instance` .
It allows to create single EC2 instance with basic options and assign arbitrary AWS tags.

@jjm , please review. And thanks for this excellent pack, works great!