### PR TITLE
`create_instance`: fix default tags parameter

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 ## Change Log
 
+## v0.7.1
+- Fix default tags parameter in `create_instance` workflow.
+
 ## v0.7.0
 - Add `create_instance` workflow.
 

--- a/actions/create_instance.yaml
+++ b/actions/create_instance.yaml
@@ -35,4 +35,5 @@ parameters:
     items:
       type: "object"
     description: "A list of AWS tag objects in form of [{'Key1': 'Value1'}, {'Key2': 'Value2'}, ...]"
-    default: ["Creator": "StackStorm aws_boto3.create_instance workflow"]
+    default:
+      - Creator: "StackStorm aws_boto3.create_instance workflow"


### PR DESCRIPTION
Hi @jjm

This PR is a follow-up for #10,  it corrects the default value for `Tags` parameter in `create_instance` workflow.
Although previous variant is sufficient and passes JSON schema validation, this one is more specific and makes YAML cleaner.