### PR TITLE
Update `create_instance` workflow

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 ## Change Log
 
+## v0.7.3
+- Add support for `BlockDeviceMappings` and `IamInstanceProfile` parameters for
+  `create_instance` workflow.
+
 ## v0.7.2
 - Version bump to fix tagging issue. No code changes.
 
@@ -12,7 +16,7 @@
 ## v0.6.0
 - Disable both the example workflows.
 - Mark `token_code` on `assume_role` as a secret.
-- Fix example `create_vpn_assume_role` workflow to correctly publish `credentials` 
+- Fix example `create_vpn_assume_role` workflow to correctly publish `credentials`
   and `assumed_role_user` details.
 - Add `properties` to `credentials` on `boto3action` and `waiter`.
 

--- a/actions/create_instance.yaml
+++ b/actions/create_instance.yaml
@@ -30,6 +30,16 @@ parameters:
     type: "string"
     description: "SSH key to use during intial instance creation"
     required: false
+  BlockDeviceMappings:
+    type: "array"
+    items:
+      type: "object"
+    description: "The block device mapping entries"
+    default: []
+  IamInstanceProfile:
+    type: "object"
+    description: "The IAM instance profile"
+    default: {}
   Tags:
     type: "array"
     items:

--- a/actions/workflows/create_instance.yaml
+++ b/actions/workflows/create_instance.yaml
@@ -7,14 +7,16 @@ vars:
       MaxCount: 1
       ImageId: "{{ImageId}}"
       InstanceType: "{{InstanceType}}"
-      # Handle SecurityGroupIds as valid array
-      SecurityGroupIds: {{SecurityGroupIds|to_json_string}}
       {% if SubnetId %}
       SubnetId: "{{SubnetId}}"
       {% endif %}
       {% if KeyName %}
       KeyName: "{{KeyName}}"
       {% endif %}
+      # Handle following params as valid arrays/objects
+      SecurityGroupIds: {{SecurityGroupIds|to_json_string}}
+      BlockDeviceMappings: {{BlockDeviceMappings|to_json_string}}
+      IamInstanceProfile: {{IamInstanceProfile|to_json_string}}
 
   # Transoform ``Tags`` array for Boto3 call
   tags: |-

--- a/pack.yaml
+++ b/pack.yaml
@@ -20,7 +20,7 @@ keywords:
   - SQS
   - lambda
 
-version : 0.7.2
+version : 0.7.3
 author : StackStorm, Inc.
 email : info@stackstorm.com
 contributors:


### PR DESCRIPTION
### What's this PR do?
Adds support for `BlockDeviceMappings` and `IamInstanceProfile` parameters in `create_instance` example workflow.

@jjm @Kami @LindsayHill Please review. Thanks!