### PR TITLE
Converted mistral workflows to orquesta using orquestaconvert

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,6 @@
 ## Change Log
+## v0.8.0
+- Convert mistral workflows to orquesta
 
 ## v0.7.4
 

--- a/actions/create_vpc.yaml
+++ b/actions/create_vpc.yaml
@@ -1,25 +1,24 @@
 ---
-name: "create_vpc"
+name: create_vpc
 pack: aws_boto3
-runner_type: "mistral-v2"
-description: "Create VPC with boto3action"
+runner_type: orquesta
+description: Create VPC with boto3action
 enabled: false
-entry_point: "workflows/create_vpc.yaml"
+entry_point: workflows/create_vpc.yaml
 parameters:
   cidr_block:
-    type: "string"
-    description: "VPC CIDR block"
+    type: string
+    description: VPC CIDR block
     required: true
   region:
-    type: "string"
-    description: "Region to create VPC"
+    type: string
+    description: Region to create VPC
     required: true
   subnet_cidr_block:
-    type: "string"
-    description: "Subnet CIDR block"
+    type: string
+    description: Subnet CIDR block
     required: true
   availability_zone:
-    type: "string"
-    description: "Availability zone to create subnet"
+    type: string
+    description: Availability zone to create subnet
     required: true
-...

--- a/actions/create_vpc_assume_role.yaml
+++ b/actions/create_vpc_assume_role.yaml
@@ -1,47 +1,46 @@
 ---
-name: "create_vpc_assume_role"
+name: create_vpc_assume_role
 pack: aws_boto3
-runner_type: "mistral-v2"
-description: "Create VPC with boto3action using assume_role"
+runner_type: orquesta
+description: Create VPC with boto3action using assume_role
 enabled: false
-entry_point: "workflows/create_vpc_assume_role.yaml"
+entry_point: workflows/create_vpc_assume_role.yaml
 parameters:
   cidr_block:
-    type: "string"
-    description: "VPC CIDR block"
+    type: string
+    description: VPC CIDR block
     required: true
   region:
-    type: "string"
-    description: "Region to create VPC"
+    type: string
+    description: Region to create VPC
     required: true
   subnet_cidr_block:
-    type: "string"
-    description: "Subnet CIDR block"
+    type: string
+    description: Subnet CIDR block
     required: true
   availability_zone:
-    type: "string"
-    description: "Availability zone to create subnet"
+    type: string
+    description: Availability zone to create subnet
     required: true
   role_arn:
-    type: "string"
-    description: "ARN of the role"
+    type: string
+    description: ARN of the role
     required: true
   aws_access_key_id:
-    type: "string"
-    description: "AWS Access Key"
+    type: string
+    description: AWS Access Key
     secret: true
   aws_secret_access_key:
-    type: "string"
-    description: "AWS Secret Access Key"
+    type: string
+    description: AWS Secret Access Key
     secret: true
   use_mfa:
-    type: "boolean"
-    description: "Include MFA details."
-    default: False
+    type: boolean
+    description: Include MFA details.
+    default: false
   serial_number:
-    type: "string"
-    description: "Serial number of the MFA"
+    type: string
+    description: Serial number of the MFA
   token_code:
-    type: "string"
-    description: "Token code from the MFA"
-...
+    type: string
+    description: Token code from the MFA

--- a/actions/workflows/create_vpc.yaml
+++ b/actions/workflows/create_vpc.yaml
@@ -1,88 +1,91 @@
 ---
-version: '2.0'
-aws_boto3.create_vpc:
-    type: direct
-    description: "Create VPC with boto3action"
+version: '1.0'
+description: Create VPC with boto3action
+input:
+  - cidr_block
+  - region
+  - subnet_cidr_block
+  - availability_zone
+tasks:
+  create_vpc:
+    action: aws_boto3.boto3action
     input:
-        - cidr_block
-        - region
-        - subnet_cidr_block
-        - availability_zone
-    tasks:
-      create_vpc:
-        action: aws_boto3.boto3action
-        input:
-          service: ec2
-          action_name: create_vpc
-          region: <% $.region %>
-          params: <% dict(CidrBlock => $.cidr_block, InstanceTenancy => "default") %>
+      service: ec2
+      action_name: create_vpc
+      region: <% ctx().region %>
+      params: <% dict(CidrBlock => ctx().cidr_block, InstanceTenancy => "default") %>
+    next:
+      - when: '{{ succeeded() }}'
         publish:
-          vpc_id: <% task(create_vpc).result.result.Vpc.VpcId %>
-        on-success:
+          - vpc_id: <% result().result.Vpc.VpcId %>
+        do:
           - create_subnet
           - create_igw
-
-      create_subnet:
-        action: aws_boto3.boto3action
-        input:
-          service: ec2
-          action_name: create_subnet
-          region: <% $.region %>
-          params: <% dict(AvailabilityZone => $.availability_zone, CidrBlock => $.subnet_cidr_block, VpcId => $.vpc_id) %>
+  create_subnet:
+    action: aws_boto3.boto3action
+    input:
+      service: ec2
+      action_name: create_subnet
+      region: <% ctx().region %>
+      params: <% dict(AvailabilityZone => ctx().availability_zone, CidrBlock => ctx().subnet_cidr_block, VpcId => ctx().vpc_id) %>
+    next:
+      - when: '{{ succeeded() }}'
         publish:
-          subnet_id: <% task(create_subnet).result.result.Subnet.SubnetId %>
-        on-success:
+          - subnet_id: <% result().result.Subnet.SubnetId %>
+        do:
           - create_route_table
-
-      create_igw:
-        action: aws_boto3.boto3action
-        input:
-          service: ec2
-          action_name: create_internet_gateway
-          region: <% $.region %>
+  create_igw:
+    action: aws_boto3.boto3action
+    input:
+      service: ec2
+      action_name: create_internet_gateway
+      region: <% ctx().region %>
+    next:
+      - when: '{{ succeeded() }}'
         publish:
-          igw_id: <% task(create_igw).result.result.InternetGateway.InternetGatewayId %>
-        on-success:
+          - igw_id: <% result().result.InternetGateway.InternetGatewayId %>
+        do:
           - attach_igw
-
-      attach_igw:
-        action: aws_boto3.boto3action
-        input:
-          service: ec2
-          action_name: attach_internet_gateway
-          region: <% $.region %>
-          params: <% dict(VpcId => $.vpc_id, InternetGatewayId => $.igw_id) %>
-        on-success:
+  attach_igw:
+    action: aws_boto3.boto3action
+    input:
+      service: ec2
+      action_name: attach_internet_gateway
+      region: <% ctx().region %>
+      params: <% dict(VpcId => ctx().vpc_id, InternetGatewayId => ctx().igw_id) %>
+    next:
+      - when: '{{ succeeded() }}'
+        do:
           - create_route_igw
-
-      create_route_table:
-        action: aws_boto3.boto3action
-        input:
-          service: ec2
-          action_name: create_route_table
-          region: <% $.region %>
-          params: <% dict(VpcId => $.vpc_id) %>
+  create_route_table:
+    action: aws_boto3.boto3action
+    input:
+      service: ec2
+      action_name: create_route_table
+      region: <% ctx().region %>
+      params: <% dict(VpcId => ctx().vpc_id) %>
+    next:
+      - when: '{{ succeeded() }}'
         publish:
-          route_table_id: <% task(create_route_table).result.result.RouteTable.RouteTableId %>
-        on-success:
+          - route_table_id: <% result().result.RouteTable.RouteTableId %>
+        do:
           - attach_route_tables
-
-      attach_route_tables:
-        action: aws_boto3.boto3action
-        input:
-          service: ec2
-          action_name: associate_route_table
-          region: <% $.region %>
-          params: <% dict(SubnetId => $.subnet_id, RouteTableId => $.route_table_id) %>
-        on-success:
+  attach_route_tables:
+    action: aws_boto3.boto3action
+    input:
+      service: ec2
+      action_name: associate_route_table
+      region: <% ctx().region %>
+      params: <% dict(SubnetId => ctx().subnet_id, RouteTableId => ctx().route_table_id) %>
+    next:
+      - when: '{{ succeeded() }}'
+        do:
           - create_route_igw
-
-      create_route_igw:
-        join: all
-        action: aws_boto3.boto3action
-        input:
-          service: ec2
-          action_name: create_route
-          region: <% $.region %>
-          params: <% dict(RouteTableId => $.route_table_id, GatewayId => $.igw_id, DestinationCidrBlock => '0.0.0.0/0') %>
-...
+  create_route_igw:
+    action: aws_boto3.boto3action
+    join: all
+    input:
+      service: ec2
+      action_name: create_route
+      region: <% ctx().region %>
+      params: <% dict(RouteTableId => ctx().route_table_id, GatewayId => ctx().igw_id, DestinationCidrBlock => '0.0.0.0/0') %>

--- a/actions/workflows/create_vpc_assume_role.yaml
+++ b/actions/workflows/create_vpc_assume_role.yaml
@@ -1,118 +1,120 @@
 ---
-version: '2.0'
-aws_boto3.create_vpc_assume_role:
-    type: direct
-    description: "Create VPC with boto3action"
+version: '1.0'
+description: Create VPC with boto3action
+input:
+  - cidr_block
+  - region
+  - subnet_cidr_block
+  - availability_zone
+  - role_arn
+  - aws_access_key_id
+  - aws_secret_access_key
+  - use_mfa
+  - serial_number
+  - token_code
+tasks:
+  assume_role:
+    action: aws_boto3.assume_role
     input:
-        - cidr_block
-        - region
-        - subnet_cidr_block
-        - availability_zone
-        - role_arn
-        - aws_access_key_id
-        - aws_secret_access_key
-        - use_mfa
-        - serial_number
-        - token_code
-    tasks:
-      assume_role:
-        action: aws_boto3.assume_role
-        input:
-          role_arn: <% $.role_arn %>
-          aws_access_key_id: <% $.aws_access_key_id %>
-          aws_secret_access_key: <% $.aws_secret_access_key %>
-          use_mfa: <% $.use_mfa %>
-          serial_number: <% $.serial_number %>
-          token_code: <% $.token_code %>
-
+      role_arn: <% ctx().role_arn %>
+      aws_access_key_id: <% ctx().aws_access_key_id %>
+      aws_secret_access_key: <% ctx().aws_secret_access_key %>
+      use_mfa: <% ctx().use_mfa %>
+      serial_number: <% ctx().serial_number %>
+      token_code: <% ctx().token_code %>
+    next:
+      - when: '{{ succeeded() }}'
         publish:
-          credentials: <% task().result.result['Credentials'] %>
-          assumed_role_user: <% task().result.result['AssumedRoleUser'] %>
-
-        on-success:
+          - credentials: <% task().result.result['Credentials'] %>
+          - assumed_role_user: <% task().result.result['AssumedRoleUser'] %>
+        do:
           - create_vpc
-
-      create_vpc:
-        action: aws_boto3.boto3action
-        input:
-          service: ec2
-          action_name: create_vpc
-          region: <% $.region %>
-          params: <% dict(CidrBlock => $.cidr_block, InstanceTenancy => "default") %>
-          credentials: <% $.credentials %>
+  create_vpc:
+    action: aws_boto3.boto3action
+    input:
+      service: ec2
+      action_name: create_vpc
+      region: <% ctx().region %>
+      params: <% dict(CidrBlock => ctx().cidr_block, InstanceTenancy => "default") %>
+      credentials: <% ctx().credentials %>
+    next:
+      - when: '{{ succeeded() }}'
         publish:
-          vpc_id: <% task().result.result.Vpc.VpcId %>
-        on-success:
+          - vpc_id: <% task().result.result.Vpc.VpcId %>
+        do:
           - create_subnet
           - create_igw
-
-      create_subnet:
-        action: aws_boto3.boto3action
-        input:
-          service: ec2
-          action_name: create_subnet
-          region: <% $.region %>
-          params: <% dict(AvailabilityZone => $.availability_zone, CidrBlock => $.subnet_cidr_block, VpcId => $.vpc_id) %>
-          credentials: <% $.credentials %>
+  create_subnet:
+    action: aws_boto3.boto3action
+    input:
+      service: ec2
+      action_name: create_subnet
+      region: <% ctx().region %>
+      params: <% dict(AvailabilityZone => ctx().availability_zone, CidrBlock => ctx().subnet_cidr_block, VpcId => ctx().vpc_id) %>
+      credentials: <% ctx().credentials %>
+    next:
+      - when: '{{ succeeded() }}'
         publish:
-          subnet_id: <% task().result.result.Subnet.SubnetId %>
-        on-success:
+          - subnet_id: <% task().result.result.Subnet.SubnetId %>
+        do:
           - create_route_table
-
-      create_igw:
-        action: aws_boto3.boto3action
-        input:
-          service: ec2
-          action_name: create_internet_gateway
-          region: <% $.region %>
-          credentials: <% $.credentials %>
+  create_igw:
+    action: aws_boto3.boto3action
+    input:
+      service: ec2
+      action_name: create_internet_gateway
+      region: <% ctx().region %>
+      credentials: <% ctx().credentials %>
+    next:
+      - when: '{{ succeeded() }}'
         publish:
-          igw_id: <% task().result.result.InternetGateway.InternetGatewayId %>
-        on-success:
+          - igw_id: <% task().result.result.InternetGateway.InternetGatewayId %>
+        do:
           - attach_igw
-
-      attach_igw:
-        action: aws_boto3.boto3action
-        input:
-          service: ec2
-          action_name: attach_internet_gateway
-          region: <% $.region %>
-          params: <% dict(VpcId => $.vpc_id, InternetGatewayId => $.igw_id) %>
-          credentials: <% $.credentials %>
-        on-success:
+  attach_igw:
+    action: aws_boto3.boto3action
+    input:
+      service: ec2
+      action_name: attach_internet_gateway
+      region: <% ctx().region %>
+      params: <% dict(VpcId => ctx().vpc_id, InternetGatewayId => ctx().igw_id) %>
+      credentials: <% ctx().credentials %>
+    next:
+      - when: '{{ succeeded() }}'
+        do:
           - create_route_igw
-
-      create_route_table:
-        action: aws_boto3.boto3action
-        input:
-          service: ec2
-          action_name: create_route_table
-          region: <% $.region %>
-          params: <% dict(VpcId => $.vpc_id) %>
-          credentials: <% $.credentials %>
+  create_route_table:
+    action: aws_boto3.boto3action
+    input:
+      service: ec2
+      action_name: create_route_table
+      region: <% ctx().region %>
+      params: <% dict(VpcId => ctx().vpc_id) %>
+      credentials: <% ctx().credentials %>
+    next:
+      - when: '{{ succeeded() }}'
         publish:
-          route_table_id: <% task().result.result.RouteTable.RouteTableId %>
-        on-success:
+          - route_table_id: <% task().result.result.RouteTable.RouteTableId %>
+        do:
           - attach_route_tables
-
-      attach_route_tables:
-        action: aws_boto3.boto3action
-        input:
-          service: ec2
-          action_name: associate_route_table
-          region: <% $.region %>
-          params: <% dict(SubnetId => $.subnet_id, RouteTableId => $.route_table_id) %>
-          credentials: <% $.credentials %>
-        on-success:
+  attach_route_tables:
+    action: aws_boto3.boto3action
+    input:
+      service: ec2
+      action_name: associate_route_table
+      region: <% ctx().region %>
+      params: <% dict(SubnetId => ctx().subnet_id, RouteTableId => ctx().route_table_id) %>
+      credentials: <% ctx().credentials %>
+    next:
+      - when: '{{ succeeded() }}'
+        do:
           - create_route_igw
-
-      create_route_igw:
-        join: 2
-        action: aws_boto3.boto3action
-        input:
-          service: ec2
-          action_name: create_route
-          region: <% $.region %>
-          params: <% dict(RouteTableId => $.route_table_id, GatewayId => $.igw_id, DestinationCidrBlock => '0.0.0.0/0') %>
-          credentials: <% $.credentials %>
-...
+  create_route_igw:
+    action: aws_boto3.boto3action
+    join: 2
+    input:
+      service: ec2
+      action_name: create_route
+      region: <% ctx().region %>
+      params: <% dict(RouteTableId => ctx().route_table_id, GatewayId => ctx().igw_id, DestinationCidrBlock => '0.0.0.0/0') %>
+      credentials: <% ctx().credentials %>

--- a/pack.yaml
+++ b/pack.yaml
@@ -19,7 +19,7 @@ keywords:
   - RDS
   - SQS
   - lambda
-version : 0.7.4
+version : 0.8.0
 author : StackStorm, Inc.
 email : info@stackstorm.com
 contributors:


### PR DESCRIPTION
With mistral removed in stackstorm 3.3 installation of this packs fails with an error because mistral is still used for the create_vpc and create_vpc_assume_role actions, this PR fixes that.
I converted the create_vpc and create_vpc_assume_role actions with [orquestaconvert](https://github.com/StackStorm/orquestaconvert)

fixes #17 