### PR TITLE
Add support for session token to assume_role action

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 ## Change Log
 
+## 1.0.1
+- Add support for AWS session token to `assume_role` action
+
 ## 1.0.0
 
 * Drop Python 2.7 support

--- a/actions/assume_role.py
+++ b/actions/assume_role.py
@@ -13,7 +13,8 @@ class Boto3AssumeRoleRunner(Action):
     def run(self, role_arn,
             policy=None, duration=3600, external_id=None,
             aws_access_key_id=None, aws_secret_access_key=None,
-            use_mfa=False, serial_number=None, token_code=None):
+            use_mfa=False, serial_number=None, token_code=None,
+            use_session_token=False, aws_session_token=None):
 
         success = False
         result = dict()
@@ -23,6 +24,9 @@ class Boto3AssumeRoleRunner(Action):
         if aws_access_key_id and aws_secret_access_key:
             sts_kwargs['aws_access_key_id'] = aws_access_key_id
             sts_kwargs['aws_secret_access_key'] = aws_secret_access_key
+        
+        if aws_session_token:
+            sts_kwargs['aws_session_token'] = aws_session_token
 
         client = boto3.client('sts', **sts_kwargs)
 

--- a/actions/assume_role.py
+++ b/actions/assume_role.py
@@ -25,7 +25,7 @@ class Boto3AssumeRoleRunner(Action):
             sts_kwargs['aws_access_key_id'] = aws_access_key_id
             sts_kwargs['aws_secret_access_key'] = aws_secret_access_key
         
-        if aws_session_token:
+        if use_session_token:
             sts_kwargs['aws_session_token'] = aws_session_token
 
         client = boto3.client('sts', **sts_kwargs)

--- a/actions/assume_role.yaml
+++ b/actions/assume_role.yaml
@@ -39,3 +39,9 @@ parameters:
     type: "string"
     description: "Token code from the MFA"
     secret: true
+  use_session_token:
+    type: "boolean"
+    description: "Include session token"
+  aws_session_token:
+    type: "string"
+    description: "Session token"

--- a/actions/assume_role.yaml
+++ b/actions/assume_role.yaml
@@ -42,6 +42,8 @@ parameters:
   use_session_token:
     type: "boolean"
     description: "Include session token"
+    default: False
   aws_session_token:
     type: "string"
     description: "Session token"
+    secret: true

--- a/pack.yaml
+++ b/pack.yaml
@@ -19,7 +19,7 @@ keywords:
   - RDS
   - SQS
   - lambda
-version: 1.0.0
+version: 1.0.1
 author : StackStorm, Inc.
 email : info@stackstorm.com
 contributors:


### PR DESCRIPTION
This PR allows a session token to be passed to the `assume_role` action for authentication to STS.

Two parameters are added, one `boolean` flag for setting if a session token will be provided (default is false), and another one for the session token itself (which will be kept secret). The session token is used as part of the STS client call. 